### PR TITLE
Fix mathjax pdf bug & Codemirror deploy bug

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -9,13 +9,15 @@ sudo apt-get install --force-yes -y --quiet wget tar curl
 # fonts (Ubuntu 14.04+)
 sudo apt-get install --force-yes -y --quite fonts-noto
 
-# mathjax 2.3
-wget -O mathjax-2.3.0.zip https://github.com/mathjax/MathJax/archive/2.3.0.zip
-unzip mathjax-2.3.0.zip -d public/ && mv public/MathJax-2.3.0 public/mathjax-2.3
+# mathjax 2.5
+wget -O mathjax-2.5.zip https://github.com/mathjax/MathJax/archive/v2.5-latest.zip
+unzip mathjax-2.5.zip -d public/ && mv public/MathJax-2.5-latest public/mathjax-2.5
+rm mathjax-2.5.zip
 
 # codemirror 3.22
 wget http://codemirror.net/codemirror-3.22.zip
-unzip codemirror-3.22.zip -d public/ && mv public/codemirror-3.22 public/codemirror
+unzip codemirror-3.22.zip -d public/
+rm codemirror-3.22.zip
 
 # phantomjs 1.9.7 x86_64
 wget https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-1.9.7-linux-x86_64.tar.bz2

--- a/views/tasks_edit.erb
+++ b/views/tasks_edit.erb
@@ -50,7 +50,7 @@
 <script type="text/javascript" src="/codemirror-3.22/lib/codemirror.js"></script>
 <script type="text/javascript" src="/codemirror-3.22/mode/markdown/markdown.js"></script>
 <script type="text/x-mathjax-config">MathJax.Hub.Config({messageStyle: "none"});</script>
-<script type="text/javascript" src="/mathjax-2.3/MathJax.js?config=TeX-AMS-MML_SVG"></script>
+<script type="text/javascript" src="/assets/mathjax-2.5/MathJax.js?config=TeX-AMS-MML_SVG"></script>
 <script type="text/javascript" src="/javascripts/marked.js"></script>
 
 <script>

--- a/views/tasks_preview.erb
+++ b/views/tasks_preview.erb
@@ -45,7 +45,7 @@
   <script src="/assets/javascripts/bootstrap.min.js"></script>
   <script src="/assets/javascripts/bootstrap-sortable.js"></script>
   <script type="text/x-mathjax-config">MathJax.Hub.Config({messageStyle: "none"});</script>
-  <script type="text/javascript" src="/mathjax-2.3/MathJax.js?config=TeX-AMS-MML_SVG"></script>
+  <script type="text/javascript" src="/assets/mathjax-2.5/MathJax.js?config=TeX-AMS-MML_SVG"></script>
   <script type="text/javascript" src="/javascripts/marked.js"></script>
   <script>
     marked.setOptions({


### PR DESCRIPTION
1) Codemirror deploy bug
Remove renaming codemirror-3.22 to codemirror at deploy.sh

2) Mathjax pdf bug
Upgrade mathjax to v2.5

3) Other changes
Add removing codemirror, mathjax zip file at deploy.sh

Please aceept the request. :+1: 
